### PR TITLE
fix missing dependency error that magically appeared today

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.eclipse.jdt/core "3.3.0-v_771"]
+                 [org.eclipse.equinox/app "1.0.0-v20070606"]
                  [org.clojure/clojure "1.4.0"]]
 
   :java-source-paths ["java"]


### PR DESCRIPTION
I have no idea what's going on, but lein was failing on everything because I had no.disassemble as a plugin, and I was getting the error that `org.eclipse.equinox:app:jar:1.0.0` couldn't be found.  I couldn't even figure out the where the transitive dependency was coming from, because `lein deps :tree` and `mvn dependency:tree` were both erroring out.  

This may not be the right solution to this (which I assume is because someone pushed a bad pom somewhere), but it seems to work.  Your call on whether to merge it or go in search of something less ad hoc.
